### PR TITLE
Replaced indexOf with Y.Array.indexOf for browsers without ECMA

### DIFF
--- a/mail.js
+++ b/mail.js
@@ -500,7 +500,7 @@ YUI(M.yui.loader).use('io-base', 'node', 'json-parse', 'panel', 'datatable-base'
         var lblstoremain = mail_get_labels_values(true).split(',');
 
         Y.each(M.local_mail.mail_labels, function (value, index) {
-            if (lblstoadd.indexOf(index) != -1) {
+            if (Y.Array.indexOf(lblstoadd, index) != -1) {
                 if (index != labelid) {
                     elem = grouplabels.one('.mail_label_'+index);
                     if (!elem) {
@@ -508,7 +508,7 @@ YUI(M.yui.loader).use('io-base', 'node', 'json-parse', 'panel', 'datatable-base'
                         grouplabels.append(elem);
                     }
                 }
-            } else if (lblstoremain.indexOf(index) == -1) {
+            } else if (Y.Array.indexOf(lblstoremain, index) == -1) {
                 if (!mail_message_view && index == labelid) {
                     grouplabels.ancestor('.mail_item').remove();
                 } else {

--- a/recipients.js
+++ b/recipients.js
@@ -127,7 +127,7 @@ YUI(M.yui.loader).use('io-base', 'node', 'json-parse', 'panel', 'datatable-base'
         if (action == 'updaterecipients') {
             if (mail_existing_recipients) {
                 Y.Array.each(mail_existing_recipients, function(recipient, index) {
-                    if (mail_recipients[3].indexOf(recipient) != -1) {
+                    if (Y.Array.indexOf(mail_recipients[3], recipient) != -1) {
                         recipients += mail_recipients[3][index]+',';
                         roleids += '3,';
                     }
@@ -253,11 +253,11 @@ YUI(M.yui.loader).use('io-base', 'node', 'json-parse', 'panel', 'datatable-base'
     var mail_remove_recipient = function(userid, roles) {
         var pos;
         Y.Array.each(roles, function(role) {
-            pos = mail_recipients[role].indexOf(userid);
+            pos = Y.Array.indexOf(mail_recipients[role], userid);
             if (pos != -1) {
                 mail_recipients[role].splice(pos, 1);
             } else {
-                if (mail_existing_recipients.indexOf(userid) != -1 && mail_recipients[3].indexOf(userid) == -1) {
+                if (Y.Array.indexOf(mail_existing_recipients, userid) != -1 && Y.Array.indexOf(mail_recipients[3], userid) == -1) {
                     mail_recipients[3].push(userid);
                 }
             }


### PR DESCRIPTION
When using the mail mod in browsers that don't support ECMA indexOf (IE8 primarily) errors get thrown. This causes the recipients interface to not work correctly. Using YUI's indexOf fixes this.
