### PR TITLE
Include message body in notification emails

### DIFF
--- a/lang/en/local_mail.php
+++ b/lang/en/local_mail.php
@@ -87,9 +87,13 @@ $string['noselectedmessages'] = 'No messages selected';
 $string['nosubject'] = '(no subject)';
 $string['notificationbody'] = '- From: {$a->user}
 
-- Subject: {$a->subject}';
+- Subject: {$a->subject}
+
+- Please login to view your message, any attachments, and to respond.';
 $string['notificationbodyhtml'] = '<p>From: {$a->user}</p>
-<p>Subject: <a href="{$a->url}">{$a->subject}</a></p>';
+<p>Subject: <a href="{$a->url}">{$a->subject}</a></p>
+<p>Message:<br>{$a->message}</p>
+<p><strong>Note:</strong> Please login to view attachements and to respond to this message<p>';
 $string['notificationsubject'] = 'New mail message in {$a}';
 $string['notingroup'] = 'You are not part of any group';
 $string['pagingsingle'] = '{$a->index} of {$a->total}';

--- a/locallib.php
+++ b/locallib.php
@@ -83,6 +83,7 @@ function local_mail_send_notifications($message) {
 
         $htmldata->user = fullname($message->sender());
         $htmldata->subject = $message->subject();
+        $htmldata->message = $message->get_content();
         $url = new moodle_url('/local/mail/view.php', array('t' => 'inbox', 'm' => $message->id()));
         $htmldata->url = $url->out(false);
 

--- a/message.class.php
+++ b/message.class.php
@@ -362,6 +362,10 @@ class local_mail_message {
         return $message;
     }
 
+    public function get_content() {
+        return $this->content;
+    }
+
     public function has_label(local_mail_label $label) {
         return isset($this->labels[$label->id()]);
     }


### PR DESCRIPTION
Thank you for your most excellent mail tool!

We get requests all the time to have the body of the message included with the notification emails.

This minor change allows that to happen without any major modifications.

Thank you for your time and consideration!