### PR TITLE
Test needs to account for zero vs false

### DIFF
--- a/compose_form.php
+++ b/compose_form.php
@@ -143,7 +143,12 @@ class mail_compose_form extends moodleform {
     public static function file_options() {
         global $COURSE, $PAGE, $CFG;
 
-        $configmaxbytes = get_config('local_mail', 'maxbytes') ?: LOCAL_MAIL_MAXBYTES;
+        $configmaxbytes = get_config('local_mail', 'maxbytes');
+        if ($configmaxbytes === false) {
+            $configmaxbytes = LOCAL_MAIL_MAXBYTES;
+        } else if ($configmaxbytes === 0) {
+            $configmaxbytes = $CFG->maxbytes;
+        }
         $configmaxfiles = get_config('local_mail', 'maxfiles');
         $maxbytes = get_user_max_upload_file_size($PAGE->context, $CFG->maxbytes,
                                                   $COURSE->maxbytes, $configmaxbytes);


### PR DESCRIPTION
The value of the "maxbytes" setting can be zero if it is set to the "Site upload limit" in the settings. If so this line will evaluate to false and set configmaxbytes to the local default. This causes the compose form to incorrectly reject attachments that are below the site limit but above the local default. If the logic is changed to explicitly test for 0 and false we get the expected behavior and compose allows attachments under the site limit.