### PR TITLE
Prevent debug warning from messagelib

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -130,7 +130,7 @@ function local_mail_send_notifications($message) {
         $eventdata->component         = 'local_mail';
         $eventdata->name              = 'mail';
         $eventdata->userfrom          = $message->sender();
-        $eventdata->userto            = $userto;
+        $eventdata->userto            = core_user::get_user($userto->id);
         $eventdata->subject           = get_string('notificationsubject', 'local_mail', $SITE->shortname);
         $eventdata->fullmessage       = $fullplainmessage;
         $eventdata->fullmessageformat = FORMAT_PLAIN;


### PR DESCRIPTION
This is a very minor issue, but when the notification event gets created the userto is missing some properties that messagelib requires. It throws a developer debug warning then reloads the user. This change prevents the debug warning and uses the same method that messagelib does to load the user.